### PR TITLE
Test/auth email2

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,9 @@ const cookieParser = require("cookie-parser");
 const usersRouter = require("./routes/users");
 const authRouter = require("./routes/auth");
 const profileRouter = require("./routes/profile");
-const postRouter = require("./routes/posts")
+const postRouter = require("./routes/posts");
+
+const emailAuthRouter = require("./routes/emailAuth");
 
 require("dotenv").config();
 
@@ -12,7 +14,7 @@ const PORT = process.env.PORT;
 
 app.use(express.json()); // 요청의 데이터를 JSON 형식으로 파싱하기 위한 미들웨어 설정
 app.use(cookieParser()); // 쿠키 파싱을 위한 미들웨어 설정
-app.use("/api", [usersRouter, profileRouter, authRouter, postRouter]);
+app.use("/api", [usersRouter, profileRouter, authRouter, postRouter, emailAuthRouter]);
 
 app.listen(PORT, () => {
   console.log(PORT, "포트 번호로 서버가 실행되었습니다.");

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
         "bcrypt": "^5.1.0",
         "cookie-parser": "^1.4.6",
         "dotenv": "^16.3.1",
+        "ejs": "^3.1.9",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.0",
         "mysql2": "^3.4.2",
+        "nodemailer": "^6.9.3",
         "nodemon": "^2.0.22",
         "sequelize": "^6.32.1",
         "sequelize-cli": "^6.6.1"
@@ -182,6 +184,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -302,6 +309,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -594,6 +635,20 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
+    "node_modules/ejs": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -742,6 +797,33 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
       "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -1192,6 +1274,23 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
+    "node_modules/jake": {
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-beautify": {
       "version": "1.14.8",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.8.tgz",
@@ -1535,6 +1634,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.3.tgz",
+      "integrity": "sha512-fy9v3NgTzBngrMFkDsKEj0r02U7jm6XfC3b52eoNV+GCrGj+s8pt5OqhiJdWKuw51zCTdiNR/IUD1z33LIIGpg==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "bcrypt": "^5.1.0",
     "cookie-parser": "^1.4.6",
     "dotenv": "^16.3.1",
+    "ejs": "^3.1.9",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
     "mysql2": "^3.4.2",
+    "nodemailer": "^6.9.3",
     "nodemon": "^2.0.22",
     "sequelize": "^6.32.1",
     "sequelize-cli": "^6.6.1"

--- a/routes/emailAuth.js
+++ b/routes/emailAuth.js
@@ -1,0 +1,51 @@
+const express = require("express");
+const router = express.Router();
+const nodemailer = require("nodemailer");
+const authTemplate = require("../template/authMail.js");
+
+// 인증 이메일 보내기
+router.post("/mail", async (req, res) => {
+  let authNum = Math.random().toString().substring(2, 6);
+
+  function validateEmail(email) {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  }
+
+  const email = req.body.email;
+  if (!validateEmail(email)) {
+    return res.status(412).json({ errorMessage: "이메일 형식이 올바르지 않습니다." });
+  }
+
+  let transporter = nodemailer.createTransport({
+    service: "gmail",
+    host: "smtp.gmail.com",
+    port: 587,
+    secure: false,
+    auth: {
+      user: process.env.NODEMAILER_USER,
+      pass: process.env.NODEMAILER_PASS
+    }
+  });
+
+  let message = {
+    from: `뉴스피드 프로젝트`,
+    to: email,
+    subject: `이메일 확인 코드: ${authNum}`,
+    html: authTemplate(authNum)
+  };
+
+  await transporter.sendMail(message, (error, info) => {
+    if (error) {
+      console.log("==Error occurred==");
+      console.log(error.message);
+      return;
+    }
+
+    console.log("Message sent successfully!");
+    console.log(nodemailer.getTestMessageUrl(info));
+    res.status(200).send({ authNum });
+  });
+});
+
+module.exports = router;

--- a/routes/emailAuth.js
+++ b/routes/emailAuth.js
@@ -8,7 +8,7 @@ router.post("/auth/mail", async (req, res) => {
   let authNum = Math.random().toString().substring(2, 6);
 
   function validateEmail(email) {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const emailRegex = /^[a-z0-9]+@[a-z]+\.[a-z]{2,3}+$/;
     return emailRegex.test(email);
   }
 

--- a/routes/emailAuth.js
+++ b/routes/emailAuth.js
@@ -4,7 +4,7 @@ const nodemailer = require("nodemailer");
 const authTemplate = require("../template/authMail.js");
 
 // 인증 이메일 보내기
-router.post("/mail", async (req, res) => {
+router.post("/auth/mail", async (req, res) => {
   let authNum = Math.random().toString().substring(2, 6);
 
   function validateEmail(email) {

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -20,9 +20,6 @@ async function create(req, res) {
     }
 
     await post.save();
-
-    // getAll API 호출
-    getAll(req, res);
   } catch (error) {
     console.error(`Error: ${error.message}`);
     return res.status(400).json({
@@ -80,8 +77,6 @@ async function update(req, res) {
     } else {
       try {
         await Posts.update({ title, content }, { where: { postId } });
-        // getAll API 호출
-        getAll(req, res);
       } catch (error) {
         res.status(401).json({ errorMessage: "게시글이 정상적으로 수정되지 않았습니다." });
       }
@@ -103,8 +98,6 @@ async function remove(req, res) {
     } else {
       try {
         await Posts.destroy({ where: { postId } });
-        // getAll API 호출
-        getAll(req, res);
       } catch (error) {
         res.status(401).json({ errorMessage: "게시글이 정상적으로 삭제되지 않았습니다." });
       }

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -1,14 +1,13 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const { Posts } = require('../models');
+const { Posts } = require("../models");
 const authMiddleware = require("../middlewares/auth-middleware");
 
-
-router.post('/posts',authMiddleware, create);
-router.get('/posts', getAll);
-router.get('/posts/:postId', getOne);
-router.put('/posts/:postId',authMiddleware, update);
-router.delete('/posts/:postId',authMiddleware, remove);
+router.post("/posts", authMiddleware, create);
+router.get("/posts", getAll);
+router.get("/posts/:postId", getOne);
+router.put("/posts/:postId", authMiddleware, update);
+router.delete("/posts/:postId", authMiddleware, remove);
 
 async function create(req, res) {
   try {
@@ -17,7 +16,7 @@ async function create(req, res) {
     const post = new Posts({ UserId, nickname, title, content });
 
     if (!title || !content) {
-      return res.status(412).json({ errorMessage: '데이터 형식이 올바르지 않습니다.' });
+      return res.status(412).json({ errorMessage: "데이터 형식이 올바르지 않습니다." });
     }
 
     await post.save();
@@ -27,21 +26,21 @@ async function create(req, res) {
   } catch (error) {
     console.error(`Error: ${error.message}`);
     return res.status(400).json({
-      message: '게시글 작성에 실패했습니다.',
+      message: "게시글 작성에 실패했습니다."
     });
   }
 }
 async function getAll(req, res) {
   try {
     const posts = await Posts.findAll({
-      attributes: ['postId', 'UserId', 'nickname', 'title', 'createdAt', 'updatedAt'],
-      order: [['createdAt', 'DESC']],
+      attributes: ["postId", "UserId", "nickname", "title", "createdAt", "updatedAt"],
+      order: [["createdAt", "DESC"]]
     });
     res.status(200).json({ posts });
   } catch (error) {
     console.error(`Error: ${error.message}`);
     res.status(400).json({
-      errorMessage: '게시글 조회에 실패했습니다.',
+      errorMessage: "게시글 조회에 실패했습니다."
     });
   }
 }
@@ -50,18 +49,18 @@ async function getOne(req, res) {
   try {
     const { postId } = req.params;
     const post = await Posts.findOne({
-      attributes: ['postId', 'UserId', 'nickname', 'title', 'content', 'createdAt', 'updatedAt'],
-      where: { postId },
+      attributes: ["postId", "UserId", "nickname", "title", "content", "createdAt", "updatedAt"],
+      where: { postId }
     });
 
     if (!post) {
-      return res.status(400).json({ errorMessage: '게시글이 존재하지 않습니다.' });
+      return res.status(400).json({ errorMessage: "게시글이 존재하지 않습니다." });
     }
 
     res.status(200).json({ post });
   } catch (error) {
     console.error(`Error: ${error.message}`);
-    res.status(400).json({ errorMessage: '데이터 형식이 올바르지 않습니다.' });
+    res.status(400).json({ errorMessage: "데이터 형식이 올바르지 않습니다." });
   }
 }
 
@@ -72,24 +71,24 @@ async function update(req, res) {
     const post = await Posts.findOne({ where: { postId } });
 
     if (!title || !content) {
-      res.status(412).json({ errorMessage: '데이터 형식이 올바르지 않습니다.' });
+      res.status(412).json({ errorMessage: "데이터 형식이 올바르지 않습니다." });
       return;
     }
 
     if (!post) {
-      res.status(404).json({ errorMessage: '게시글 조회에 실패하였습니다.' });
+      res.status(404).json({ errorMessage: "게시글 조회에 실패하였습니다." });
     } else {
       try {
         await Posts.update({ title, content }, { where: { postId } });
         // getAll API 호출
         getAll(req, res);
       } catch (error) {
-        res.status(401).json({ errorMessage: '게시글이 정상적으로 수정되지 않았습니다.' });
+        res.status(401).json({ errorMessage: "게시글이 정상적으로 수정되지 않았습니다." });
       }
     }
   } catch (error) {
     console.error(`Error: ${error.message}`);
-    return res.status(400).json({ errorMessage: '게시글 수정에 실패했습니다.' });
+    return res.status(400).json({ errorMessage: "게시글 수정에 실패했습니다." });
   }
 }
 
@@ -100,19 +99,19 @@ async function remove(req, res) {
 
     // 게시글이 존재하지 않을 경우 404
     if (!post) {
-      return res.status(404).json({ errorMessage: '게시글 조회에 실패하였습니다.' });
+      return res.status(404).json({ errorMessage: "게시글 조회에 실패하였습니다." });
     } else {
       try {
         await Posts.destroy({ where: { postId } });
         // getAll API 호출
         getAll(req, res);
       } catch (error) {
-        res.status(401).json({ errorMessage: '게시글이 정상적으로 삭제되지 않았습니다.' });
+        res.status(401).json({ errorMessage: "게시글이 정상적으로 삭제되지 않았습니다." });
       }
     }
   } catch (error) {
     console.error(`Error: ${error.message}`);
-    return res.status(400).json({ errorMessage: '게시글 삭제에 실패했습니다.' });
+    return res.status(400).json({ errorMessage: "게시글 삭제에 실패했습니다." });
   }
 }
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -16,12 +16,12 @@ router.post("/users/signup", async (req, res) => {
     // req.body로 받아오기
     const { email, nickname, password, confirmPassword, verifiedEmail } = req.body;
     // 중복되는 닉네임과 이메일검사
-    const isExisUser = await Users.findOne({
+    const isExistUser = await Users.findOne({
       where: {
         email: email
       }
     });
-    const isExisNick = await Users.findOne({
+    const isExistNick = await Users.findOne({
       where: {
         nickname: nickname
       }
@@ -29,10 +29,10 @@ router.post("/users/signup", async (req, res) => {
 
     // email이나 nickname이 중복이 되는 유적가 있을 경우
     // eamil중복확인
-    if (isExisUser) {
+    if (isExistUser) {
       return res.status(409).json({ errorMessage: "이미 존재하는 회원입니다." });
     }
-    if (isExisNick) {
+    if (isExistNick) {
       return res.status(412).json({ errorMessage: "이미 존재하는 닉네임입니다." });
     }
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -14,7 +14,7 @@ router.post("/users/signup", async (req, res) => {
     const passwordEex = /^[^]{4,}$/; // 아무값[^]
     const nickNameEex = /^[a-z0-9]{3,}$/;
     // req.body로 받아오기
-    const { email, nickname, password, confirmPassword } = req.body;
+    const { email, nickname, password, confirmPassword, verifiedEmail } = req.body;
     // 중복되는 닉네임과 이메일검사
     const isExisUser = await Users.findOne({
       where: {
@@ -44,6 +44,11 @@ router.post("/users/signup", async (req, res) => {
     // 이메일 규칙검사
     if (!emailExp.test(email)) {
       res.status(412).json({ errorMessage: "이메일주소형식이 올바르지 않습니다." });
+      return;
+    }
+
+    if (!verifiedEmail) {
+      res.status(412).json({ errorMessage: "이메일을 인증해주세요." });
       return;
     }
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -46,7 +46,7 @@ router.post("/users/signup", async (req, res) => {
       res.status(412).json({ errorMessage: "이메일주소형식이 올바르지 않습니다." });
       return;
     }
-
+    // TODO: 이메일 인증을 하면 회원가입 API 내에서 형식 검사를 하지 않아도 된다.
     if (!verifiedEmail) {
       res.status(412).json({ errorMessage: "이메일을 인증해주세요." });
       return;

--- a/routes/users.js
+++ b/routes/users.js
@@ -10,7 +10,6 @@ const saltRounds = 10;
 // 회원가입 API
 router.post("/users/signup", async (req, res) => {
   try {
-    const emailExp = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
     const passwordEex = /^[^]{4,}$/; // 아무값[^]
     const nickNameEex = /^[a-z0-9]{3,}$/;
     // req.body로 받아오기
@@ -41,12 +40,7 @@ router.post("/users/signup", async (req, res) => {
       res.status(412).json({ errorMessage: "닉네임은 최소 3자이상, 알파벳 소문자 숫자를 포함하여야합니다." });
       return;
     }
-    // 이메일 규칙검사
-    if (!emailExp.test(email)) {
-      res.status(412).json({ errorMessage: "이메일주소형식이 올바르지 않습니다." });
-      return;
-    }
-    // TODO: 이메일 인증을 하면 회원가입 API 내에서 형식 검사를 하지 않아도 된다.
+
     if (!verifiedEmail) {
       res.status(412).json({ errorMessage: "이메일을 인증해주세요." });
       return;

--- a/template/authMail.js
+++ b/template/authMail.js
@@ -1,0 +1,15 @@
+const authMail = authNum => {
+  const template = `<html>
+     <body>
+       <div>
+         <p style="color: black">회원 가입을 위한 인증번호 입니다.</p>
+         <p style="color: black">아래의 인증 번호를 입력하여 인증을 완료해주세요.</p>         
+        <div style="font-size: 36px; margin-top: 20px; line-height: 44px;">${authNum}</div>
+       </div>
+     </body>
+   </html>
+   `;
+  return template;
+};
+
+module.exports = authMail;


### PR DESCRIPTION
인증 이메일 전송 API 구현

회원가입 시 이메일을 입력하고 '인증하기'버튼을 누르면 API가 호출된다.
이메일 형식을 검사하고 형식이 틀리면 에러메시지를 응답한다.
형식이 옳으면 입력한 이메일로 메일을 전송한다. 메일에는 랜덤으로 생성한 4자리 숫자를 인증코드로  보낸다.
이메일 전송에 성공하면 프론트에 인증코드를 응답한다.

회원가입 API에서 이메일이 인증되지 않으면 에러코드를 반환한다.

TODO:
프론트에서 verifiedEmali을 선언하고 false를 할당한다.
프론트에서 입력받은 인증코드와 서버에서 응답받은 인증코드가 일치하면 verifiedEmail에 true를 할당한다.
회원가입 시 body에 verifiedEmali을 담아서 서버로 보낸다.

---
